### PR TITLE
Fix uniqueSlice() calculation in day9 part1

### DIFF
--- a/day9/aoc9.go
+++ b/day9/aoc9.go
@@ -50,11 +50,10 @@ func pointEqual(a point, b point) bool {
 
 func uniqueSlice(sl []point) []point {
 	res := make([]point, 0)
-
-	prev := point{}
-
+	prev := sl[0]
+	res = append(res, prev)
 	for _, v := range sl {
-		if (prev == point{}) || (prev != point{} && !pointEqual(prev, v)) {
+		if !pointEqual(prev, v) {
 			res = append(res, v)
 		}
 		prev = v


### PR DESCRIPTION
Initializing prev to point{} causes its x and y to be nil, or in this case 0,0. And since 0,0 is a valid point that soon will be found, the check that prev hasn't been initialized did not work as intended.

To fix this, prev is now set to the first point in the slice, and directly added (since it is by definition unique) and then we just simply go through all points and add those that are not identical as the previous one.