### PR TITLE
Read Go version from go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.24'
+        go-version-file: go.mod
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
Instead of having Go version hardcoded in the Github actions workflow, read it from the go.mod file.